### PR TITLE
Add the --raw option to `countfastq.sh`

### DIFF
--- a/cc_assembler.R
+++ b/cc_assembler.R
@@ -35,6 +35,7 @@ metric <- commandArgs(trailingOnly = TRUE)[2]
 gene_names <- commandArgs(trailingOnly = TRUE)[3]
 design_str <- commandArgs(trailingOnly = TRUE)[4]
 target_path <- commandArgs(trailingOnly = TRUE)[5]
+raw <- commandArgs(trailingOnly = TRUE)[6]
 
 ## # Check level name.
 ## if (! level %in% c("genes", "isoforms")) {
@@ -117,7 +118,12 @@ for (file in file_list) {
   # count_matrix. Perform an outer join by 'RSEM_key' (gene_id/transcript_id).
   # Also rename sample column heading using subfolder name as sample name.
   count_column <- df[,c(RSEM_key, metric)]
-  colnames(count_column)[2] <- paste(basename(dirname(file)), metric, sep = "_")
+  colnames(count_column)[2] <- if (raw == "true") {
+      basename(dirname(file))
+    } else {
+      paste(basename(dirname(file)), metric, sep = "_")
+    }
+  
   
   # Check genome/transcriptome size.
   entries[length(entries)+1] <- dim(count_column)[1]

--- a/countfastq.sh
+++ b/countfastq.sh
@@ -12,7 +12,7 @@ set -u # "no-unset" shell option
 # --- Function definition ------------------------------------------------------
 
 # Default options
-ver="1.2.0"
+ver="1.3.0"
 verbose=true
 gene_names=false
 metric="TPM"
@@ -56,6 +56,8 @@ function _help_countfastq {
 	echo "  -n | --names     Appends gene symbols and names as annotations."
 	echo "  -i | --isoforms  Assembles counts at the transcript level instead"
 	echo "                   of gene (the default level)."
+    echo "  -r | --raw       Do not include the name of the metric in the column"
+    echo "                   names."
 	echo "  --design=\"SUFFX\" Injects an experimental design into the heading of"
 	echo "                   the final expression matrix by adding a suffix to"
 	echo "                   each sample name. Suffixes must be as many in"
@@ -155,6 +157,10 @@ while [[ $# -gt 0 ]]; do
 				level="isoforms"
 				shift
 			;;
+			-r | --raw)
+				raw=true
+				shift
+			;;
 			--design*)
 				# Test for '=' presence
 				rgx="^--design="
@@ -228,5 +234,5 @@ _dual_log $verbose "$log_file" "\n\
 	Working at ${level%s} level with $metric metric"
 
 nohup Rscript "${xpath}"/cc_assembler.R \
-	"$level" "$metric" "$gene_names" "$design" "$target_dir" \
+	"$level" "$metric" "$gene_names" "$design" "$target_dir" "$raw" \
 	>> "$log_file" 2>&1 &


### PR DESCRIPTION
This fixes #9.

The `--raw` flag makes `countfastq` to not include the name of the metric in the output columns. For example:
```
countfastq --metric="expected_count" -r
head Count_Matrix_genes_expected_count.tsv
```
results in
```
gene_id	SRR222175	SRR222176	SRR222177	SRR222178
ENSG00000000003	282	161	709	666.68
ENSG00000000005	3	0	0	3
ENSG00000000419	59	84.71	149	349.92
ENSG00000000457	47.06	39.7	145.78	172.9
ENSG00000000460	4.95	8.3	31.22	84.11
ENSG00000000938	34	73	64	44
ENSG00000000971	84.61	100.92	695.31	476.76
ENSG00000001036	188.71	291	561.01	596.2
ENSG00000001084	76.83	80.83	268.85	342.88
```