### PR TITLE
Make anqfastq -p less verbose

### DIFF
--- a/anqfastq.sh
+++ b/anqfastq.sh
@@ -23,7 +23,7 @@ set -e # "exit-on-error" shell option
 set -u # "no-unset" shell option
 
 # Default options
-ver="1.6.7"
+ver="1.6.8"
 verbose=true
 verbose_external=true
 progress_or_kill=false
@@ -188,7 +188,13 @@ function _progress_anqfastq {
 		line=$(grep -n "============" "$latest_log" | \
 			cut -d ":" -f 1 | tail -n 2 | head -n 1)
 		
-		tail -n +${line} "$latest_log"      
+        # the 'uniq' removes the highly repeated 'ROUND = xxx' lines generated
+        # by 'rsem', keeping only the last ROUND.
+        # This has the unfortunate side effect of removing ALL duplicated lines
+        # that are adjacent and that start with the same 8 characters, but I
+        # hope this does not happen elsewhere in the parsed piece of log.
+		tail -n +${line} "$latest_log" | \
+            tac - | uniq -w 8 | tac
 		exit 0 # Success exit status
 	else
 		printf "No anqFASTQ log file found in '$(realpath "$target_dir")'.\n"


### PR DESCRIPTION
`uniq` removes *adjacent* duplicate lines. Using it, we can remove the highly repeated lines that `rsem` prints out, keeping only the last one.

Having this log snippet (as produced by the current `anqfastq -p` and manually trimmed by hand for clarity):
```
These are some header lines! 

so Nice!
WOW!!!
ROUND = 4806, SUM = 10125424.0000001, bChange = 0.00110851, totNum = 1
ROUND = 4807, SUM = 10125424.0000001, bChange = 0.00110851, totNum = 1
ROUND = 4808, SUM = 10125424.0000001, bChange = 0.00110851, totNum = 1
ROUND = 4809, SUM = 10125424.0000001, bChange = 0.00110851, totNum = 1
ROUND = 4810, SUM = 10125424.0000001, bChange = 0.00110851, totNum = 1
ROUND = 4811, SUM = 10125424.0000001, bChange = 0.00110851, totNum = 1
ROUND = 4812, SUM = 10125424.0000001, bChange = 0.00110852, totNum = 1
ROUND = 4813, SUM = 10125424.0000001, bChange = 0.00110852, totNum = 1
ROUND = 4814, SUM = 10125424.0000001, bChange = 0.00110852, totNum = 1
ROUND = 4815, SUM = 10125424.0000001, bChange = 0.00110852, totNum = 1
ROUND = 4816, SUM = 10125424.0000001, bChange = 0.00110852, totNum = 1
ROUND = 4817, SUM = 10125424.0000001, bChange = 0.00110852, totNum = 1
ROUND = 4818, SUM = 10125424.0000001, bChange = 0.00110852, totNum = 1
ROUND = 4819, SUM = 10125424.0000001, bChange = 0.00110852, totNum = 1
ROUND = 4820, SUM = 10125424.0000001, bChange = 0.00110852, totNum = 1
ROUND = 4821, SUM = 10125424.0000001, bChange = 0.00110852, totNum = 1
ROUND = 4822, SUM = 10125424.0000001, bChange = 0.00110852, totNum = 1
ROUND = 4823, SUM = 10125424.0000001, bChange = 0.00110852, totNum = 1
ROUND = 4824, SUM = 10125424.0000001, bChange = 0.00110852, totNum = 1
ROUND = 4825, SUM = 10125424.0000001, bChange = 0.00110852, totNum = 1
ROUND = 4826, SUM = 10125424.0000001, bChange = 0.00110853, totNum = 1
ROUND = 4827, SUM = 10125424.0000001, bChange = 0.00110853, totNum = 1
ROUND = 4828, SUM = 10125424.0000001, bChange = 0.00110853, totNum = 1
ROUND = 4829, SUM = 10125424.0000001, bChange = 0.00110853, totNum = 1
ROUND = 4830, SUM = 10125424.0000001, bChange = 0.00110853, totNum = 1
ROUND = 4831, SUM = 10125424.0000001, bChange = 0.00110853, totNum = 1
ROUND = 4832, SUM = 10125424.0000001, bChange = 0.000967724, totNum = 0
Expression Results are written!
Time Used for EM.cpp : 0 h 12 m 44 s

rm -rf /home/hedmad/Files/tprof_geo/GSE29580/Counts/SRR222178/RSEM.temp

DONE!
```

We get this:
```
These are some header lines! 

so Nice!
WOW!!!
ROUND = 4832, SUM = 10125424.0000001, bChange = 0.000967724, totNum = 0
Expression Results are written!
Time Used for EM.cpp : 0 h 12 m 44 s

rm -rf /home/hedmad/Files/tprof_geo/GSE29580/Counts/SRR222178/RSEM.temp

DONE!
```

With the command `cat test.txt | tac | uniq -w 8 | tac`. Breaking it down:
- The `cat` is there to mimick some unknown upstream pipeline that gives us the log snippet.
- `tac` reads the stream in reverse;
- `uniq` removes all adjacent lines that are identical by the first `8` characters (`-w 8`);
- `tac` re-reverses the stream so we can read it.
We need the two `tac`s since `uniq` keeps the *first* unique line, but we want the last `ROUND`, not the first.

This has the unfortunate side effect of getting rid of *all* duplicated lines (identical by the first 8 characters), but I hope such lines are only the ones from `rsem`.
If we want to avoid this, it will not be so easy or elegant, I think.

This PR adds the fix directly in `anqfastq -p`.